### PR TITLE
ROC-2989: Use auto configuration to initialise components

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The two main responsibilities are:
 - [JDK 8](https://www.oracle.com/java)
 - [Docker](https://www.docker.com)
 
+## Usage
+
+Just include the library as your dependency and you will be to use the client class. Health check for DM service is provided as well.
+
+Components provided by this library will get automatically configured in a Spring context if `document_management.api_gateway.url` configuration property is defined and does not equal `false`. 
+ 
 ### Building
 
 The project uses [Gradle](https://gradle.org) as a build tool but you don't have install it locally since there is a

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 group 'uk.gov.hmcts.reform'
-version '1.1.0'
+version '1.1.1'
 
 checkstyle {
   maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/document/DocumentManagementClientAutoConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/document/DocumentManagementClientAutoConfiguration.java
@@ -7,12 +7,12 @@ import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.document.healthcheck.DocumentManagementHealthIndicator;
 
 @Configuration
+@ConditionalOnProperty(prefix = "document_management", name = "api_gateway.url")
 @EnableFeignClients(basePackages = "uk.gov.hmcts.reform.document")
 public class DocumentManagementClientAutoConfiguration {
 
     @Bean
-    @ConditionalOnProperty(prefix = "document_management", name = "api_gateway.url")
-    public DocumentManagementHealthIndicator healthIndicator(
+    public DocumentManagementHealthIndicator documentManagement(
         DocumentMetadataDownloadClientApi documentMetadataDownloadClientApi
     ) {
         return new DocumentManagementHealthIndicator(documentMetadataDownloadClientApi);

--- a/src/main/java/uk/gov/hmcts/reform/document/DocumentMetadataDownloadClientApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/document/DocumentMetadataDownloadClientApi.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.document;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.codec.Decoder;
 import feign.jackson.JacksonDecoder;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -36,9 +36,8 @@ public interface DocumentMetadataDownloadClientApi {
     class DownloadConfiguration {
         @Bean
         @Primary
-        @Scope("prototype")
-        Decoder feignDecoder() {
-            return new JacksonDecoder();
+        Decoder feignDecoder(ObjectMapper objectMapper) {
+            return new JacksonDecoder(objectMapper);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/document/healthcheck/DocumentManagementHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/document/healthcheck/DocumentManagementHealthIndicator.java
@@ -2,20 +2,16 @@ package uk.gov.hmcts.reform.document.healthcheck;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.document.DocumentMetadataDownloadClientApi;
 
-@Component
 public class DocumentManagementHealthIndicator implements HealthIndicator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DocumentManagementHealthIndicator.class);
 
     private final DocumentMetadataDownloadClientApi documentMetadataDownloadClientApi;
 
-    @Autowired
     public DocumentManagementHealthIndicator(
         final DocumentMetadataDownloadClientApi documentMetadataDownloadClientApi) {
         this.documentMetadataDownloadClientApi = documentMetadataDownloadClientApi;

--- a/src/main/java/uk/gov/hmcts/reform/document/healthcheck/InternalHealth.java
+++ b/src/main/java/uk/gov/hmcts/reform/document/healthcheck/InternalHealth.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.document.healthcheck;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.boot.actuate.health.Status;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -11,9 +10,9 @@ public class InternalHealth {
 
     @JsonCreator
     public InternalHealth(
-        @JsonProperty("status") Status status
+        String status
     ) {
-        this.status = status;
+        this.status = new Status(status);
     }
 
     public Status getStatus() {


### PR DESCRIPTION
This change makes sure that no DM related components are being initialised if the DM url configuration property is not provided.