### PR TITLE
Upgrade spring 2.0.6 -> 2.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,12 @@ dependencyManagement {
   imports {
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
   }
+  dependencies {
+    // CVE-2019-10086 until 1.9.3
+    dependencySet(group: 'commons-beanutils', version: '1.9.4') {
+      entry 'commons-beanutils'
+    }
+  }
 }
 
 bootJar {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 plugins {
   id 'checkstyle'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-  id 'org.springframework.boot' version '2.0.6.RELEASE'
+  id 'org.springframework.boot' version '2.3.1.RELEASE'
   id 'com.github.ben-manes.versions' version '0.28.0'
   id 'org.owasp.dependencycheck' version '5.3.2.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ bintray {
 }
 
 ext {
-  springCloudVersion = 'Finchley.RELEASE'
+  springCloudVersion = 'Hoxton.SR5'
 }
 
 dependencies {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,9 +12,6 @@
       Will be gone when checkstyle plugin is updated
     ]]></notes>
     <gav regex="true">^.*$</gav>
-<!--    <cpe>cpe:/a:apache:commons_beanutils</cpe>-->
-    <cve>CVE-2019-10086</cve>
-<!--    <cpe>cpe:/a:checkstyle:checkstyle</cpe>-->
     <cve>CVE-2019-10782</cve>
     <cve>CVE-2019-9658</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,69 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
+  <suppress until="2020-10-01">
+    <notes><![CDATA[No fix is available]]></notes>
+    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5\.3\.3\.RELEASE$</gav>
+    <cve>CVE-2018-1258</cve>
+  </suppress>
+
   <suppress>
     <notes><![CDATA[
-      Will review once dependencies are brought back to speed.
-      So far OWASP was not even in this project
+      Will be gone when checkstyle plugin is updated
     ]]></notes>
     <gav regex="true">^.*$</gav>
-    <cpe>cpe:/a:apache:commons_beanutils</cpe>
-    <cpe>cpe:/a:apache:log4j</cpe>
-    <cpe>cpe:/a:checkstyle:checkstyle</cpe>
-    <cpe>cpe:/a:google:guava</cpe>
-    <cpe>cpe:/a:pivotal_software:spring_framework</cpe>
-    <cpe>cpe:/a:pivotal_software:spring_security</cpe>
-    <cpe>cpe:/a:fasterxml:jackson</cpe>
-    <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
-    <cpe>cpe:/a:netty:netty</cpe>
-    <cpe>cpe:/a:vmware:springsource_spring_framework</cpe>
-    <!-- checkstyle -->
+<!--    <cpe>cpe:/a:apache:commons_beanutils</cpe>-->
+    <cve>CVE-2019-10086</cve>
+<!--    <cpe>cpe:/a:checkstyle:checkstyle</cpe>-->
     <cve>CVE-2019-10782</cve>
     <cve>CVE-2019-9658</cve>
-    <!-- commons bean utils -->
-    <cve>CVE-2019-10086</cve>
-    <!-- guava -->
-    <cve>CVE-2018-10237</cve>
-    <!-- jackson -->
-    <cve>CVE-2018-19360</cve>
-    <cve>CVE-2018-19361</cve>
-    <cve>CVE-2018-19362</cve>
-    <cve>CVE-2018-1000873</cve>
-    <cve>CVE-2019-12086</cve>
-    <cve>CVE-2019-12384</cve>
-    <cve>CVE-2019-12814</cve>
-    <cve>CVE-2019-14379</cve>
-    <cve>CVE-2019-14439</cve>
-    <cve>CVE-2019-14540</cve>
-    <cve>CVE-2019-14892</cve>
-    <cve>CVE-2019-14893</cve>
-    <cve>CVE-2019-16335</cve>
-    <cve>CVE-2019-16942</cve>
-    <cve>CVE-2019-16943</cve>
-    <cve>CVE-2019-17267</cve>
-    <cve>CVE-2019-17531</cve>
-    <cve>CVE-2019-20330</cve>
-    <cve>CVE-2020-8840</cve>
-    <cve>CVE-2020-9546</cve>
-    <cve>CVE-2020-9547</cve>
-    <cve>CVE-2020-9548</cve>
-    <cve>CVE-2020-10672</cve>
-    <cve>CVE-2020-10673</cve>
-    <cve>CVE-2020-10968</cve>
-    <cve>CVE-2020-10969</cve>
-    <cve>CVE-2020-11111</cve>
-    <cve>CVE-2020-11112</cve>
-    <cve>CVE-2020-11113</cve>
-    <cve>CVE-2020-11619</cve>
-    <cve>CVE-2020-11620</cve>
-    <!-- spring core -->
-    <cve>CVE-2020-5398</cve>
-    <!-- bouncycastle -->
-    <cve>CVE-2017-13098</cve>
-    <cve>CVE-2018-1000180</cve>
-    <cve>CVE-2018-1000613</cve>
-    <!-- hystrix core -->
-    <vulnerabilityName>CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')</vulnerabilityName>
   </suppress>
 
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/document/DocumentMetadataDownloadClientApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/document/DocumentMetadataDownloadClientApi.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.document.healthcheck.InternalHealth;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @FeignClient(name = "document-management-metadata-download-api", url = "${document_management.url}",
     configuration = DocumentMetadataDownloadClientApi.DownloadConfiguration.class)
@@ -34,7 +34,7 @@ public interface DocumentMetadataDownloadClientApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/health",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_UTF8_VALUE
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
     )
     InternalHealth health();
 


### PR DESCRIPTION
### Change description ###

Lot of vulnerabilities have been resolved by this upgrade with extra bean utils management.

Next PR - checkstyle upgrade which will leave the usual single vulnerability left - spring-security-crypto

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
